### PR TITLE
#6933: Enhance IconSymbolizer and Contrast enhancement

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -90,6 +90,10 @@
                 },
                 "gammaValue": {
                     "type": "number"
+                },
+                "vendorOption": {
+                    "$ref": "http://geostyler/geostyler-style.json#/definitions/VendorOption",
+                    "description": "A VendorOption defines the algorithm to apply for Normalize contrast enhancement."
                 }
             },
             "type": "object"
@@ -298,6 +302,17 @@
                 },
                 "color": {
                     "description": "A color defined as a hex-color string.",
+                    "type": "string"
+                },
+                "format": {
+                    "description": "The format (MIME type) of the image provided.",
+                    "enum": [
+                        "image/gif",
+                        "image/jpeg",
+                        "image/jpg",
+                        "image/png",
+                        "image/svg+xml"
+                    ],
                     "type": "string"
                 },
                 "haloBlur": {
@@ -1110,6 +1125,26 @@
                 "visibility": {
                     "description": "Defines whether the Symbolizer should be visibile or not.",
                     "type": "boolean"
+                }
+            },
+            "type": "object"
+        },
+        "VendorOption": {
+            "description": "A VendorOption defines the algorithm to apply for Normalize contrast enhancement.",
+            "properties": {
+                "algorithm": {
+                    "enum": [
+                        "ClipToMinimumMaximum",
+                        "ClipToZero",
+                        "StretchToMinimumMaximum"
+                    ],
+                    "type": "string"
+                },
+                "maxValue": {
+                    "type": "number"
+                },
+                "minValue": {
+                    "type": "number"
                 }
             },
             "type": "object"

--- a/schema.json
+++ b/schema.json
@@ -92,8 +92,28 @@
                     "type": "number"
                 },
                 "vendorOption": {
-                    "$ref": "http://geostyler/geostyler-style.json#/definitions/VendorOption",
-                    "description": "A VendorOption defines the algorithm to apply for Normalize contrast enhancement."
+                    "$ref": "http://geostyler/geostyler-style.json#/definitions/ContrastEnhancementVendorOption",
+                    "description": "A ContrastEnhancementVendorOption defines the algorithm to apply for Normalize contrast enhancement."
+                }
+            },
+            "type": "object"
+        },
+        "ContrastEnhancementVendorOption": {
+            "description": "A ContrastEnhancementVendorOption defines the algorithm to apply for Normalize contrast enhancement.",
+            "properties": {
+                "algorithm": {
+                    "enum": [
+                        "ClipToMinimumMaximum",
+                        "ClipToZero",
+                        "StretchToMinimumMaximum"
+                    ],
+                    "type": "string"
+                },
+                "maxValue": {
+                    "type": "number"
+                },
+                "minValue": {
+                    "type": "number"
                 }
             },
             "type": "object"
@@ -1125,26 +1145,6 @@
                 "visibility": {
                     "description": "Defines whether the Symbolizer should be visibile or not.",
                     "type": "boolean"
-                }
-            },
-            "type": "object"
-        },
-        "VendorOption": {
-            "description": "A VendorOption defines the algorithm to apply for Normalize contrast enhancement.",
-            "properties": {
-                "algorithm": {
-                    "enum": [
-                        "ClipToMinimumMaximum",
-                        "ClipToZero",
-                        "StretchToMinimumMaximum"
-                    ],
-                    "type": "string"
-                },
-                "maxValue": {
-                    "type": "number"
-                },
-                "minValue": {
-                    "type": "number"
                 }
             },
             "type": "object"

--- a/style.ts
+++ b/style.ts
@@ -360,6 +360,10 @@ export interface IconSymbolizer extends BasePointSymbolizer {
    */
   image?: string;
   /**
+   * The format (MIME type) of the image provided.
+   */
+  format?: `image/${'png' | 'jpg' | 'jpeg' | 'gif' | 'svg+xml'}`;
+  /**
    * If true, the icon will be kept upright.
    */
   keepUpright?: boolean;
@@ -550,11 +554,21 @@ export interface ColorMap {
 }
 
 /**
+ * A VendorOption defines the algorithm to apply for Normalize contrast enhancement.
+ */
+export interface VendorOption {
+  algorithm?: 'StretchToMinimumMaximum' | 'ClipToMinimumMaximum' | 'ClipToZero';
+  minValue?: number;
+  maxValue?: number;
+}
+
+/**
  * A ContrastEnhancement defines how the contrast of image data should be enhanced.
  */
 export interface ContrastEnhancement {
   enhancementType?: 'normalize' | 'histogram';
   gammaValue?: number;
+  vendorOption?: VendorOption;
 }
 
 /**

--- a/style.ts
+++ b/style.ts
@@ -554,10 +554,10 @@ export interface ColorMap {
 }
 
 /**
- * A VendorOption defines the algorithm to apply for Normalize contrast enhancement.
+ * A ContrastEnhancementVendorOption defines the algorithm to apply for Normalize contrast enhancement.
  */
-export interface VendorOption {
-  algorithm?: 'StretchToMinimumMaximum' | 'ClipToMinimumMaximum' | 'ClipToZero';
+export interface ContrastEnhancementVendorOption {
+  algorithm: 'StretchToMinimumMaximum' | 'ClipToMinimumMaximum' | 'ClipToZero';
   minValue?: number;
   maxValue?: number;
 }
@@ -568,7 +568,7 @@ export interface VendorOption {
 export interface ContrastEnhancement {
   enhancementType?: 'normalize' | 'histogram';
   gammaValue?: number;
-  vendorOption?: VendorOption;
+  vendorOption?: ContrastEnhancementVendorOption;
 }
 
 /**


### PR DESCRIPTION
## Description
This PR extends the IconSymbolizer and ContrastEnhancement interface with new properties

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Enhancement

##Issue

**What is the current behavior?**
[#6933](https://github.com/geosolutions-it/mapstore2/issues/6933) & [#1453](https://github.com/geostyler/geostyler/issues/1453)

**What is the new behavior?**
- Allows us to pass format value to Icon symbolizer for the image provided
- Allows us to pass vendor option to Contrast enhancement (Normalize Contrast Enhancement)

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

## Other useful information
